### PR TITLE
getMFCCs now by default runs dbToLinear on items; getFFT method added so...

### DIFF
--- a/src/modules/core/vowelworm.game.js
+++ b/src/modules/core/vowelworm.game.js
@@ -32,16 +32,6 @@ window.VowelWorm.Game = function( options ) {
   game.silence = -70;
 
   /**
-   * Used for storing frequency data.
-   * Chrome does not adequately garbage collect typed arrays, so this shouldn't
-   * be created in a repeatedly-called function--otherwise we'll run up memory
-   * pretty fast.
-   *
-   * TODO - the VowelWorm core code needs to handle this, not this game module
-   */ 
-  var buffer = new Float32Array(1024);
-
-  /**
    * Contains all instances of worms for this game
    * @type Array.<Object>
    */
@@ -126,7 +116,7 @@ window.VowelWorm.Game = function( options ) {
   });
   
   var getCoords = function(worm){
-    worm._analyzer.getFloatFrequencyData(buffer);
+    var buffer = worm.getFFT();
 
     if(isSilent(buffer)) {
       return null;
@@ -135,7 +125,8 @@ window.VowelWorm.Game = function( options ) {
     var position = worm.getMFCCs({
       minFreq: game.minHz,
       maxFreq: game.maxHz,
-      filterBanks: game.fb
+      filterBanks: game.fb,
+      fft: buffer
     });
     
     if(position.length) {

--- a/src/modules/worm/vowelworm.draw.js
+++ b/src/modules/worm/vowelworm.draw.js
@@ -246,8 +246,7 @@ window.VowelWorm.module('draw', function createDrawModule(worm) {
     var stage    = this._stage;
     var renderer = this._renderer;     
 
-    var values = new Float32Array(worm.getFFTSize()/2);
-    worm._analyzer.getFloatFrequencyData(values);
+    var values = worm.getFFT();
 
     var smoothed_values = worm.hann(values, 75).slice(window.VowelWorm.HANNING_SHIFT)
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -58,7 +58,8 @@ test("MFCC", function() {
     filterBanks: 10,
     minFreq: 300,
     maxFreq: 8000,
-    sampleRate: 44100
+    sampleRate: 44100,
+    toLinearMagnitude: false
   });
   var expected = [ 7.835884051228317, 1.1605377428549413, -0.174171119713941, 1.3509315849239385, -0.1991916156746527, 1.1153378031810444, -0.12527438596350143, 0.7039658412425222, -0.06616022000494146, 0.24848612991692026 ];
   deepEqual(response.map(_round), expected.map(_round));


### PR DESCRIPTION
... we don't expose the _analyzer member.
